### PR TITLE
2023 Prospectus Update

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -165,9 +165,9 @@ closed-captioning:
 # If false, hides sponsors link in navigation and footer
 show-sponsors: false
 # Toggles whether prospectus button displays on homepage and sponsor pages
-sponsor-buttons: false
+sponsor-buttons: true
 # URL to document
-prospectus-document: https://drive.google.com/file/d/11oFZcxx5F_gCdkJ5S7WIzUom-AkNxuAM/view?usp=sharing
+prospectus-document: https://drive.google.com/file/d/1J6oOSqwsXQSGFs9AUHH2LW8IJDwX2AFN/view?usp=sharing
 sponsor-btn-link: 'https://www.concentra-cms.com/c4l23sponsorreg.html'
 
 ##########

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -168,7 +168,7 @@ show-sponsors: false
 sponsor-buttons: false
 # URL to document
 prospectus-document: https://drive.google.com/file/d/11oFZcxx5F_gCdkJ5S7WIzUom-AkNxuAM/view?usp=sharing
-sponsor-btn-link: 'https://www.concentra-cms.com/c4l22sponsorreg.html'
+sponsor-btn-link: 'https://www.concentra-cms.com/c4l23sponsorreg.html'
 
 ##########
 # !!!NOTE!!! All 'end-date' vars should be in the following format: YYYY-MM-DD

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -332,7 +332,7 @@ published: true
             </div>
 
             <div class="col-12">
-                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with the Code4lib community on-site, and visibility throughout the conference. Participants will be able to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
+                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with the Code4lib community on-site, and visibility throughout the conference. Participants will be able to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately following daily sessions. General sponsors are encouraged to also get exhibitor tables. Exhibitor Tables include one complimentary conference registration.</p>
             </div>
         </div>
 
@@ -346,7 +346,7 @@ published: true
     <div class="thumbnail" id="contact_inner">
         <h2>Sponsor Contact</h2>
         <p>
-            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>. Exhibitor Tables include one complimentary conference registration.
+            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>.
         </p>
     </div>
 </div>

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -37,7 +37,7 @@ published: true
                   <ul>
                     <li>Conference speakers and programs are chosen by a voting process open to the entire community.</li>
                     <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was captioned in real-time to promote accessibility, and the community is committed to continuing this service.</li>
-                    <!--<li>Diversity scholarships help members of underrepresented communities attend the conference and take advantage of learning and networking opportunities. Many individual community members donate personally to increase the number of scholarships.</li>-->
+                    <li>Diversity scholarships help members of underrepresented communities attend the conference and take advantage of learning and networking opportunities. Many individual community members donate personally to increase the number of scholarships.</li>
                     <li>Our single-track format promotes broad sharing of ideas; the 20-minute time limit for presentations allows topics on a wide variety of technologies.</li>
                   </ul>
                 </p>
@@ -55,9 +55,9 @@ published: true
                   Code4Lib offers a nexus for technical professionals from galleries, libraries, museums, and archives. Through sponsoring the conference, you can help create connections between projects and individuals, encourage good ideas to cross the gaps between subcommunities, and spawn new ideas. You can also help practitioners level up their skills in technology as well as collaboration with professionals in different areas of expertise.
                 </p>
 
-                <!-- <p>
+                <p>
                   The Code4Lib community takes inclusion and equity seriously. By sponsoring Code4Lib's diversity scholarships, you can help ensure that the attendees better represent the mix of people that galleries, libraries, museums, and archives technology should both embody and serve.
-                </p> -->
+                </p>
 
                 <p>
                   Your sponsorship of the conference can also provide immediate, concrete benefits to you and your organization. Code4Lib attendees include active practitioners who may be interested in your product, open source project, or services as well as department heads and senior administrators (approximately 17% of attendees last year) who make purchase decisions. Sponsors are strongly encouraged to send their staff to the conference to take advantage of access to the people and ideas who make up the Code4Lib community.

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -114,7 +114,7 @@ published: true
                       <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
                       <li>Exhibitor Table</li>
                       <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                      <li>Sponsorship Recognition on the #general Code4Lib Slack Channel. Reaching an audience of almost 3,000 members!</li>
                       <li>2 free conference registrations</li>
                     </ul>
                 </div>
@@ -135,7 +135,7 @@ published: true
                       <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
                       <li>Exhibitor Table</li>
                       <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                      <li>Sponsorship Recognition on the #general Code4Lib Slack Channel. Reaching an audience of almost 3,000 members!</li>
                       <li>1 free conference registration</li>
                     </ul>
                 </div>
@@ -246,7 +246,7 @@ published: true
                 <div class="thumbnail">
                     <a name="Captioning"></a>
                     <h4>Captioning Sponsor</h4>
-                    <p><strong><span class="text-danger">None available</span> at $1,500</strong></p>
+                    <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
                         To facilitate universal participation and access to conference content, real-time live transcription and closed captioning of all presentations, lightning talks, and announcements at the annual Code4Lib conference will be included with the webstream, along with full transcription after the fact to accompany recordings. Sponsor benefits will include:
                     </p>
@@ -263,7 +263,7 @@ published: true
                 <div class="thumbnail">
                     <a name="Video-Production"></a>
                     <h4>Post-Conference Video Production Sponsor</h4>
-                    <p><strong><span class="text-danger">1 available</span> at $1,500</strong></p>
+                    <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
                         Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor benefits include:
                     </p>
@@ -282,47 +282,26 @@ published: true
                     <a name="Food"></a>
                     <h4>Food & Beverage Sponsors</h4>
                     <p>
-                        <strong><span class="text-danger">5 Break Sponsors</span> at $2,000</strong>
-                        <strong><span class="text-danger">3 Breakfast Sponsors</span> at $3,000</strong>
-                        <strong><span class="text-danger">2 Lunch Sponsors</span> at $4,000</strong>
+                        <strong><span class="text-danger">4 available</span> at $1,500</strong>
                     </p>
                     <p>
                         Each year, almost 20% of our attendees identify that they have dietary needs that we need to be aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to providing meals to all of our conference attendees so everyone is included in the dining events. There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to provide meals and ensure accurate labeling that accommodates each of our attendee’s needs. Sponsor benefits will include:
                     </p>
                     <ul>
-                        <li>Signage at the sponsored meal acknowledging the Sponsor</li>
+                        <li>Signage at all meals acknowledging Sponsorship</li>
                         <li>Small logo on the conference website as Food & Beverage Sponsor</li>
                         <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                         <li>Logo on the forthcoming Menu website page</li>
-                        <li>Name on the conference T-shirt (OR small logo if sponsoring at $3,000 or more)</li>
-                    </ul>
-                </div>
-            </div>
-
-
-            <div class="col-12">
-                <div class="thumbnail">
-                    <a name="Transportation"></a>
-                    <h4>Transportation Sponsorship</h4>
-                    <p><strong><span class="text-danger">1 available</span> at $2,000</strong></p>
-                    <p>
-                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L events. Transportation options may include shuttle buses and/or metro rail cards, as needed. Sponsor benefits will include:
-                    </p>
-                    <ul>
-                        <li>Signage acknowledging the Sponsor</li>
-                        <li>Small logo on the conference website as Transportation Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                         <li>Name on the conference T-shirt</li>
                     </ul>
                 </div>
             </div>
 
-
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Diversity"></a>
                     <h4>Diversity Scholarships</h4>
-                    <p><strong><span class="text-danger">None available</span> at $1,500</strong></p>
+                    <p><strong><span class="text-danger">10 available</span> at $2,000</strong></p>
                     <p>*Note: Funds have carried over from previous conferences and we have the majority of our Diversity Scholarships already funded for this year.</p>
                     <p>
                         These scholarships provide travel costs and conference fees for qualified applicants from groups typically underrepresented at the conference, including international attendees, transgender people, and underrepresented ethnic and racial groups. Applicants must be interested in actively contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
@@ -348,8 +327,7 @@ published: true
             <div class="col-12">
                 <ul>
                     <li><strong>Non-profit organization: $500</strong></li>
-                    <li><strong>For-profit organization, early-bird (on or before April 1, 2022): $900</strong></li>
-                    <li><strong>For-profit organization, normal rate: $1,300</strong></li>
+                    <li><strong>For-profit organization: $900</strong></li>
                 </ul>
             </div>
 
@@ -368,7 +346,7 @@ published: true
     <div class="thumbnail" id="contact_inner">
         <h2>Sponsor Contact</h2>
         <p>
-            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>.
+            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>. Exhibitor Tables include one complimentary conference registration.
         </p>
     </div>
 </div>


### PR DESCRIPTION
This PR updates the 2023 Prospectus page with the goal of activating the Prospectus link in the website's top menu.

This PR will include:
- [x] Updated Sponsorship Text
- [x] 2023 Sponsorship Registration Link
- [x] 2023 Sponsorship 1 page PDF file
- [x] changing `sponsor-buttons` to `true`