### PR TITLE
fixes issue #8

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -180,14 +180,14 @@ sponsor-btn-link: 'https://www.concentra-cms.com/c4l23sponsorreg.html'
 ###########
 
 keynote-proposals:
-  show: false
-  submission-form: ''
-  end-date: ''
+  show: true
+  submission-form: 'https://wiki.code4lib.org/2023_Keynote_Speakers_Nominations'
+  end-date: '2022-11-29'
 
 workshop-proposals:
-  show: false
-  submission-form: ''
-  end-date: ''
+  show: true
+  submission-form: 'https://forms.gle/e1fgutRMHRxJJwVQ7'
+  end-date: '2022-11-30'
 
 talk-proposals:
   show: true


### PR DESCRIPTION
Add [pre-conferences](https://forms.gle/e1fgutRMHRxJJwVQ7) and [keynotes](https://wiki.code4lib.org/2023_Keynote_Speakers_Nominations) to main page.

<img width="1257" alt="Screenshot 2022-11-08 at 3 07 23 PM" src="https://user-images.githubusercontent.com/7999195/200664639-a2f26e76-82e4-45d5-beff-56fe81f4d2b8.png">
