### PR TITLE
Hide Keynote Proposal link on home page

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -180,7 +180,7 @@ sponsor-btn-link: 'https://www.concentra-cms.com/c4l23sponsorreg.html'
 ###########
 
 keynote-proposals:
-  show: true
+  show: false
   submission-form: 'https://wiki.code4lib.org/2023_Keynote_Speakers_Nominations'
   end-date: '2022-11-29'
 


### PR DESCRIPTION
Hides link to Keynote Proposals on home page. Merge after midnight on 11/29.