### PR TITLE
tweaking language for slack signup

### DIFF
--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -206,7 +206,7 @@ active: Attend Code4Lib
                 <p>
                     You can also connect with us via
                     <a href="{{ site.data.conf.social-links.slack}}">Slack</a>
-                    (requires <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">registration</a>),
+                    (<a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">sign up here</a>),
                     <a href="https://twitter.com/hashtag/{{site.data.conf.hashtag}}">Twitter</a>, and
                     <a href="{{ site.data.conf.social-links.irc}}">IRC</a>.
                 </p>

--- a/general-info/first-timers.html
+++ b/general-info/first-timers.html
@@ -107,7 +107,7 @@ active: First Timers
 
       <h2>IRC/Twitter/Slack</h2>
       <p>
-          Use the #{{ site.data.conf.hashtag }} hashtag for conference related tweets, posts, pictures, and so on. The <a href="http://code4lib.org/irc">IRC channel</a> is #code4lib, and there will be volunteers at the conference who would be more than happy to help you with IRC. We also have a <a href="https://code4lib.slack.com/">Code4Lib Slack</a> (requires <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">registration</a>) that volunteers can help you get set up at the conference. All channels are very active during the conference so check these channels often for announcements, information, etc.
+          Use the #{{ site.data.conf.hashtag }} hashtag for conference related tweets, posts, pictures, and so on. The <a href="http://code4lib.org/irc">IRC channel</a> is #code4lib, and there will be volunteers at the conference who would be more than happy to help you with IRC. We also have a <a href="https://code4lib.slack.com/">Code4Lib Slack</a> (<a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">sign up here</a>) that volunteers can help you get set up at the conference. All channels are very active during the conference so check these channels often for announcements, information, etc.
       </p>
 
 


### PR DESCRIPTION
I received some feedback that using "registration" for Slack signup was possibly confusing with conference registration, so I'm tweaking the language to "sign up here" instead.