### PR TITLE
Fixing typo

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -84,7 +84,7 @@
 - timeImg: 10.05.png
   title: Breakout Sessions 2
   day3: true
-  time: 11:00-10:45
+  time: 11:00-11:45
   link: https://wiki.code4lib.org/Code4Lib2023_Breakout_Sessions
   button_label: View sessions
 


### PR DESCRIPTION
Making the breakout session 45 minutes instead of -15