### PR TITLE
Displaying workshop info and links on general info page

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -142,6 +142,10 @@ slide-template:
 closed-captioning:
   url:
 
+workshops:
+  show: true
+  location: rabinowitz
+
 # Peri display descriptions and titles
 #peri:
 #  day1-am-title: 'Pre-Conference'

--- a/general-info/venues/workshops.html
+++ b/general-info/venues/workshops.html
@@ -1,12 +1,15 @@
 <section class="general-info">
     <div class="col-12">
         <h2 id="workshops">Workshops</h2>
-		{% unless site.data.conf.workshops.show %}
-            Stay tuned… When the information of the workshops is confirmed, the details will be added here.
+        {% if site.data.conf.workshops.show %}
+        {% assign location = site.data.locations | where: 'id', site.data.conf.workshops.location | first %}
+        <p>
+            All Pre-Conference workshops will be held {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date-data | date: "%B %-d, %Y" }}{% if location %} in <a href="{{ location.google_maps }}">{{ location.name }}</a>{% endif %}. Please see the <a href="/workshops/">schedule</a> for more information.
+        </p>
         {% else %}
         <p>
-            All Pre-Conference workshops will be held {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date-data | date: "%B %-d, %Y" }}.
+            Stay tuned… When the information of the workshops is confirmed, the details will be added here.
         </p>
-		{% endunless %}
+        {% endif %}
     </div>
 </section>


### PR DESCRIPTION
* Display workshop info instead of a placeholder on the venues page
* Link to venue Google Maps URL