### PR TITLE
Community Support schedule

### DIFF
--- a/_data/community-support-schedule.yml
+++ b/_data/community-support-schedule.yml
@@ -11,9 +11,114 @@ onsite:
   #   volunteers:
   #     - surname
   #     - othersurname
+  - day: Tuesday
+    period: Morning Preconferences
+    volunteers:
+      - anne-slaughter
+  - day: Tuesday
+    period: Afternoon Preconferences
+    volunteers:
+      - ann-marie-mesco
+  - day: Wednesday
+    period: 8:30am - 11am
+    volunteers:
+      - soojeong-herring
+      - francis-kayiwa
+  - day: Wednesday
+    period: 11am - 1pm
+    volunteers:
+      - andromeda-yelton
+      - bess-sadler
+  - day: Wednesday
+    period: 1pm - 3pm
+    volunteers:
+      - carolyn-cole
+      - sharon-clapp
+  - day: Wednesday
+    period: 3pm - 5pm
+    volunteers:
+      - anne-slaughter
+      - ann-marie-mesco
+  - day: Wednesday
+    period: Reception
+    volunteers:
+      - andromeda-yelton
+      - bobbi-fox
+      - esme-cowles
+  - day: Thursday
+    period: 8:30am - 11am
+    volunteers:
+      - carolyn-cole
+      - francis-kayiwa
+  - day: Thursday
+    period: 11am - 1pm
+    volunteers:
+      - ann-marie-mesco
+      - bobbi-fox
+  - day: Thursday
+    period: 1pm - 3pm
+    volunteers:
+      - soojeong-herring
+      - sharon-clapp
+  - day: Thursday
+    period: 3pm - 5pm
+    volunteers:
+      - andromeda-yelton
+      - bess-sadler
+  - day: Thursday
+    period: Game Night
+    volunteers:
+      - soojeong-herring
+      - esme-cowles
+  - day: Friday
+    period: 8:30am - 11am
+    volunteers:
+      - bobbi-fox
+      - sharon-clapp
+  - day: Friday
+    period: 11am - 1pm
+    volunteers:
+      - francis-kayiwa
+      - carolyn-cole
 
 online:
   # template:
   # - day:
   #   period:
   #   volunteer:
+  - day: Tuesday
+    period: Morning Preconferences
+    volunteer: eric-phetteplace
+  - day: Tuesday
+    period: Afternoon Preconferences
+    volunteer: mike-giarlo
+  - day: Wednesday
+    period: 8:30am - 11am
+    volunteer: esme-cowles
+  - day: Wednesday
+    period: 11am - 1pm
+    volunteer: kevin-reiss
+  - day: Wednesday
+    period: 1pm - 3pm
+    volunteer: mike-giarlo
+  - day: Wednesday
+    period: 3pm - 5pm
+    volunteer: eric-phetteplace
+  - day: Thursday
+    period: 8:30am - 11am
+    volunteer: kevin-reiss
+  - day: Thursday
+    period: 11am - 1pm
+    volunteer: esme-cowles
+  - day: Thursday
+    period: 1pm - 3pm
+    volunteer: eric-phetteplace
+  - day: Thursday
+    period: 3pm - 5pm
+    volunteer: mike-giarlo
+  - day: Friday
+    period: 8:30am - 11am
+    volunteer: kevin-reiss
+  - day: Friday
+    period: 11am - 1pm
+    volunteer: esme-cowles

--- a/conduct/index.html
+++ b/conduct/index.html
@@ -1,6 +1,6 @@
 ---
 layout: secondary-nav
-title: Venue
+title: Conduct
 nav: conduct
 active: 'Conduct & Safety'
 ---
@@ -204,7 +204,7 @@ active: 'Conduct & Safety'
                                             {% else %}
                                                 <img alt="{{ volunteer.name }}" class="clip-circle-lg" src="{{ volunteer.img }}" alt="{{ volunteer.name }}">
                                             {% endif %}
-			
+
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Hi! This PR does two things:

- add the Community Support (CSV) schedule
- fix the conduct page `<title>`

You can double check the CSV schedule data against [this spreadsheet](https://docs.google.com/spreadsheets/d/1Odoxx_5CFO8b7jqi2pQnN0ZKmZaGfpfiho4PWFym9EI/edit?usp=sharing) but I did triple-check so I hope it's accurate 🙂 there's a good chance we will need to make an adjustment before the conference but this is a good starting point at least.